### PR TITLE
MemCpy example

### DIFF
--- a/src/main/cpp/app/main.cpp
+++ b/src/main/cpp/app/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <ctime>
 using namespace std;
 #include "platform.h"
 
@@ -6,6 +7,8 @@ using namespace std;
 #include "DRAMExample.hpp"
 void Run_DRAMExample(WrapperRegDriver * platform) {
   DRAMExample t(platform);
+  struct timespec tic, toc;
+  float total_time;
 
   cout << "Signature: " << hex << t.get_signature() << dec << endl;
   unsigned int ub = 0;
@@ -31,9 +34,13 @@ void Run_DRAMExample(WrapperRegDriver * platform) {
   t.set_baseAddr((AccelDblReg) accelBuf);
   t.set_byteCount(bufsize);
 
+  clock_gettime(CLOCK_MONOTONIC, &tic);
+
   t.set_start(1);
 
   while(t.get_finished() != 1);
+
+  clock_gettime(CLOCK_MONOTONIC, &toc);
 
   platform->deallocAccelBuffer(accelBuf);
   delete [] hostBuf;
@@ -42,6 +49,12 @@ void Run_DRAMExample(WrapperRegDriver * platform) {
   cout << "Result = " << res << " expected " << golden << endl;
   unsigned int cc = t.get_cycleCount();
   cout << "#cycles = " << cc << " cycles per word = " << (float)cc/(float)ub << endl;
+
+  total_time = ((float)(toc.tv_nsec-tic.tv_nsec))/((float)1000000000) + (float)(toc.tv_sec-tic.tv_sec);
+  cout << "Elapsed time(s): " << total_time << ", ";
+  cout << "Time per word(s): " << total_time/ub << ", ";
+  cout << "Frequency(Mhz): " << ub/(1000000*total_time) << endl;
+
   t.set_start(0);
 }
 
@@ -50,6 +63,8 @@ void Run_DRAMExample(WrapperRegDriver * platform) {
 #include "MemCpyExample.hpp"
 void Run_MemCpyExample(WrapperRegDriver * platform) {
   MemCpyExample t(platform);
+  struct timespec tic, toc;
+  float total_time;
 
   cout << "Signature: " << hex << t.get_signature() << dec << endl;
   unsigned int ub = 0;
@@ -77,9 +92,13 @@ void Run_MemCpyExample(WrapperRegDriver * platform) {
   t.set_destAddr((AccelDblReg) accelDstBuf);
   t.set_byteCount(bufsize);
 
+  clock_gettime(CLOCK_MONOTONIC, &tic);
+
   t.set_start(1);
 
   while(t.get_finished() != 1);
+
+  clock_gettime(CLOCK_MONOTONIC, &toc);
 
   platform->copyBufferAccelToHost(accelDstBuf, hostDstBuf, bufsize);
 
@@ -106,6 +125,12 @@ void Run_MemCpyExample(WrapperRegDriver * platform) {
   }
   unsigned int cc = t.get_cycleCount();
   cout << "#cycles = " << cc << " cycles per word = " << (float)cc/(float)ub << endl;
+
+  total_time = ((float)(toc.tv_nsec-tic.tv_nsec))/((float)1000000000) + (float)(toc.tv_sec-tic.tv_sec);
+  cout << "Elapsed time(s): " << total_time << ", ";
+  cout << "Time per word(s): " << total_time/ub << ", ";
+  cout << "Frequency(Mhz): " << ub/(1000000*total_time) << endl;
+
   t.set_start(0);
 }
 */

--- a/src/main/cpp/app/main.cpp
+++ b/src/main/cpp/app/main.cpp
@@ -2,6 +2,50 @@
 using namespace std;
 #include "platform.h"
 
+// uncomment this block for the DRAMExample
+#include "DRAMExample.hpp"
+void Run_DRAMExample(WrapperRegDriver * platform) {
+  DRAMExample t(platform);
+
+  cout << "Signature: " << hex << t.get_signature() << dec << endl;
+  unsigned int ub = 0;
+  // why divisible by 16? fpgatidbits DMA components may not work if the
+  // number of bytes is not divisible by 64. since we are using 4-byte words,
+  // 16*4=64 ensures divisibility.
+  cout << "Enter upper bound of sum sequence, divisible by 16: " << endl;
+  cin >> ub;
+  if(ub % 16 != 0) {
+    cout << "Error: Upper bound must be divisible by 16" << endl;
+    return;
+  }
+
+  unsigned int * hostBuf = new unsigned int[ub];
+  unsigned int bufsize = ub * sizeof(unsigned int);
+  unsigned int golden = (ub*(ub+1))/2;
+
+  for(unsigned int i = 0; i < ub; i++) { hostBuf[i] = i+1; }
+
+  void * accelBuf = platform->allocAccelBuffer(bufsize);
+  platform->copyBufferHostToAccel(hostBuf, accelBuf, bufsize);
+
+  t.set_baseAddr((AccelDblReg) accelBuf);
+  t.set_byteCount(bufsize);
+
+  t.set_start(1);
+
+  while(t.get_finished() != 1);
+
+  platform->deallocAccelBuffer(accelBuf);
+  delete [] hostBuf;
+
+  AccelReg res = t.get_sum();
+  cout << "Result = " << res << " expected " << golden << endl;
+  unsigned int cc = t.get_cycleCount();
+  cout << "#cycles = " << cc << " cycles per word = " << (float)cc/(float)ub << endl;
+  t.set_start(0);
+}
+
+/*
 // uncomment this block for the MemCpy example
 #include "MemCpyExample.hpp"
 void Run_MemCpyExample(WrapperRegDriver * platform) {
@@ -58,50 +102,6 @@ void Run_MemCpyExample(WrapperRegDriver * platform) {
   } else {
     cout << "Error at word: " << words << endl;
   }
-  unsigned int cc = t.get_cycleCount();
-  cout << "#cycles = " << cc << " cycles per word = " << (float)cc/(float)ub << endl;
-  t.set_start(0);
-}
-
-/*
-// uncomment this block for the DRAMExample
-#include "DRAMExample.hpp"
-void Run_DRAMExample(WrapperRegDriver * platform) {
-  DRAMExample t(platform);
-
-  cout << "Signature: " << hex << t.get_signature() << dec << endl;
-  unsigned int ub = 0;
-  // why divisible by 16? fpgatidbits DMA components may not work if the
-  // number of bytes is not divisible by 64. since we are using 4-byte words,
-  // 16*4=64 ensures divisibility.
-  cout << "Enter upper bound of sum sequence, divisible by 16: " << endl;
-  cin >> ub;
-  if(ub % 16 != 0) {
-    cout << "Error: Upper bound must be divisible by 16" << endl;
-    return;
-  }
-
-  unsigned int * hostBuf = new unsigned int[ub];
-  unsigned int bufsize = ub * sizeof(unsigned int);
-  unsigned int golden = (ub*(ub+1))/2;
-
-  for(unsigned int i = 0; i < ub; i++) { hostBuf[i] = i+1; }
-
-  void * accelBuf = platform->allocAccelBuffer(bufsize);
-  platform->copyBufferHostToAccel(hostBuf, accelBuf, bufsize);
-
-  t.set_baseAddr((AccelDblReg) accelBuf);
-  t.set_byteCount(bufsize);
-
-  t.set_start(1);
-
-  while(t.get_finished() != 1);
-
-  platform->deallocAccelBuffer(accelBuf);
-  delete [] hostBuf;
-
-  AccelReg res = t.get_sum();
-  cout << "Result = " << res << " expected " << golden << endl;
   unsigned int cc = t.get_cycleCount();
   cout << "#cycles = " << cc << " cycles per word = " << (float)cc/(float)ub << endl;
   t.set_start(0);
@@ -207,8 +207,8 @@ int main()
   //Run_TestRegOps(platform);
   //Run_TestAccumulateVector(platform);
   //Run_BRAMExample(platform);
-  //Run_DRAMExample(platform);
-  Run_MemCpyExample(platform);
+  //Run_MemCpyExample(platform);
+  Run_DRAMExample(platform);
 
   deinitPlatform(platform);
 

--- a/src/main/cpp/app/main.cpp
+++ b/src/main/cpp/app/main.cpp
@@ -96,6 +96,8 @@ void Run_MemCpyExample(WrapperRegDriver * platform) {
     }
   }
   if (success) words = ub;
+  delete [] hostSrcBuf;
+  delete [] hostDstBuf;
 
   if (success) {
     cout << words << " words copied successfully!" << endl;

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,8 +9,8 @@ object Settings {
   //val myInstFxn = {() => new TestRegOps()}
   //val myInstFxn = {() => new TestAccumulateVector(4)}
   //val myInstFxn = {() => new BRAMExample(1024)}
-  //val myInstFxn = {() => new DRAMExample()}
-  val myInstFxn = {() => new MemCpyExample()}
+  //val myInstFxn = {() => new MemCpyExample()}
+  val myInstFxn = {() => new DRAMExample()}
 }
 
 // call this object's main method to generate Chisel Verilog and C++ emulation

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,7 +9,8 @@ object Settings {
   //val myInstFxn = {() => new TestRegOps()}
   //val myInstFxn = {() => new TestAccumulateVector(4)}
   //val myInstFxn = {() => new BRAMExample(1024)}
-  val myInstFxn = {() => new DRAMExample()}
+  //val myInstFxn = {() => new DRAMExample()}
+  val myInstFxn = {() => new MemCpyExample()}
 }
 
 // call this object's main method to generate Chisel Verilog and C++ emulation

--- a/src/main/scala/MemCpyExample.scala
+++ b/src/main/scala/MemCpyExample.scala
@@ -24,7 +24,7 @@ class MemCpyExample() extends RosettaAccelerator {
   val rdP = new StreamReaderParams(
     streamWidth = 32, /* read a stream of 32 bits */
     fifoElems = 8,    /* add a stream FIFO of 8 elements */
-    mem = PYNQParams.toMemReqParams(),  /* PYNQ memory request parameters */
+    mem = PYNQZ1Params.toMemReqParams(),  /* PYNQ memory request parameters */
     maxBeats = 1, /* do not use bursts (set to e.g. 8 for better DRAM bandwidth)*/
     chanID = 0, /* stream ID for distinguishing between returned responses */
     disableThrottle = true  /* disable throttling */
@@ -39,7 +39,7 @@ class MemCpyExample() extends RosettaAccelerator {
   // stream
   val wdP = new StreamWriterParams(
     streamWidth = 32, /* read a stream of 32 bits */
-    mem = PYNQParams.toMemReqParams(),  /* PYNQ memory request parameters */
+    mem = PYNQZ1Params.toMemReqParams(),  /* PYNQ memory request parameters */
     maxBeats = 1, /* do not use bursts (set to e.g. 8 for better DRAM bandwidth)*/
     chanID = 0 /* stream ID for distinguishing between returned responses */
   )

--- a/src/main/scala/MemCpyExample.scala
+++ b/src/main/scala/MemCpyExample.scala
@@ -1,0 +1,97 @@
+package rosetta
+
+import Chisel._
+import fpgatidbits.dma._
+import fpgatidbits.streams._
+import fpgatidbits.PlatformWrapper._
+
+// Copy memory from a source to target.
+class MemCpyExample() extends RosettaAccelerator {
+  val numMemPorts = 2
+  val io = new RosettaAcceleratorIF(numMemPorts) {
+    val start = Bool(INPUT)
+    val finished = Bool(OUTPUT)
+    val srcAddr = UInt(INPUT, width = 64)
+    val destAddr = UInt(INPUT, width = 64)
+    val byteCount = UInt(INPUT, width = 32)
+    val cycleCount = UInt(OUTPUT, width = 32)
+  }
+  // to read the data stream from DRAM, we'll use a component called StreamReader
+  // from fpgatidbits.dma:
+  // https://github.com/maltanar/fpga-tidbits/blob/master/src/main/scala/fpgatidbits/dma/StreamReader.scala
+  // we'll start by describing the "static" (unchanging) properties of the data
+  // stream
+  val rdP = new StreamReaderParams(
+    streamWidth = 32, /* read a stream of 32 bits */
+    fifoElems = 8,    /* add a stream FIFO of 8 elements */
+    mem = PYNQParams.toMemReqParams(),  /* PYNQ memory request parameters */
+    maxBeats = 1, /* do not use bursts (set to e.g. 8 for better DRAM bandwidth)*/
+    chanID = 0, /* stream ID for distinguishing between returned responses */
+    disableThrottle = true  /* disable throttling */
+  )
+  // now instantiate the StreamReader with these parameters
+  val reader = Module(new StreamReader(rdP)).io
+
+  // to read the data stream from DRAM, we'll use a component called StreamWriter
+  // from fpgatidbits.dma:
+  // https://github.com/maltanar/fpga-tidbits/blob/master/src/main/scala/fpgatidbits/dma/StreamWriter.scala
+  // we'll start by describing the "static" (unchanging) properties of the data
+  // stream
+  val wdP = new StreamWriterParams(
+    streamWidth = 32, /* read a stream of 32 bits */
+    mem = PYNQParams.toMemReqParams(),  /* PYNQ memory request parameters */
+    maxBeats = 1, /* do not use bursts (set to e.g. 8 for better DRAM bandwidth)*/
+    chanID = 0 /* stream ID for distinguishing between returned responses */
+  )
+  // now instantiate the StreamWriter with these parameters
+  val writer = Module(new StreamWriter(wdP)).io
+
+  // wire up the stream reader and writer to the parameters that will be
+  // specified by the user at runtime
+  // start signal
+  reader.start := io.start
+  reader.baseAddr := io.srcAddr    // pointer to start of the source data
+  writer.start := io.start
+  writer.baseAddr := io.destAddr    // pointer to start of the destination
+
+  // number of bytes to read for both reader and writer
+  // IMPORTANT: it's best to provide a byteCount which is divisible by
+  // 64, as the fpgatidbits streaming DMA components have some limitations.
+  reader.byteCount := io.byteCount
+  writer.byteCount := io.byteCount
+
+  // indicate when the transfer is finished.
+  io.finished := writer.finished
+
+  // push the read stream into the writer
+  reader.out <> writer.in
+
+  // wire up the read requests-responses against the memory port interface
+  reader.req <> io.memPort(0).memRdReq
+  io.memPort(0).memRdRsp <> reader.rsp
+
+  // plug the unused write port
+  io.memPort(0).memWrReq.valid := Bool(false)
+  io.memPort(0).memWrDat.valid := Bool(false)
+  io.memPort(0).memWrRsp.ready := Bool(false)
+
+  // wire up the write requests-responses against the memory port interface
+  writer.req <> io.memPort(1).memWrReq
+  io.memPort(1).memWrRsp <> writer.rsp
+  writer.wdat <> io.memPort(1).memWrDat
+
+  // plug the unused read port
+  plugMemReadPort(1)  // read port not used
+
+  // instantiate a cycle counter for benchmarking
+  val regCycleCount = Reg(init = UInt(0, 32))
+  io.cycleCount := regCycleCount
+  when(!io.start) {regCycleCount := UInt(0)}
+  .elsewhen(io.start & !io.finished) {regCycleCount := regCycleCount + UInt(1)}
+
+  io.led := io.btn
+
+  // the signature can be e.g. used for checking that the accelerator has the
+  // correct version. here the signature is regenerated from the current date.
+  io.signature := makeDefaultSignature()
+}


### PR DESCRIPTION
## MemCpy Example
Created a class to instantiate the hardware under `src/main/scala/MemCpyExample.scala`, and added commented code for generating the hardware in `src/main/scala/Main.scala`. Similar to the other examples, the host code is added in comments in `src/main/cpp/app/main.cpp`.

### Run the Example
In order to try the example do the following:
1. Comment the Run_DRAMExample function in and the function call in the main function in `src/main/cpp/app/main.cpp`
2. Uncomment the Run_MemCpyExample function and the coresponding function call in main in `src/main/cpp/app/main.cpp`
3. Uncomment the line `val myInstFxn = {() => new MemCpyExample()}` from `src/main/scala/MemCpyExample.scala` and comment the line relating to the DRAM example.
4. Follow the instructions in README.md to build the overlay, rsync the files, load the bitstream, compile the example and run the app.
5. When prompted, enter the number of words you'd like to copy from a source location to a destination.