### PR TITLE
Update Rosetta to support Pynq v2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ bitfile: hw_vivadoproj
 
 # copy bitfile to the deployment folder, make an empty tcl script for bitfile loader
 pynq_hw: bitfile
-	mkdir -p $(BUILD_DIR_PYNQ); cp $(GEN_BITFILE_PATH) $(BUILD_DIR_PYNQ)/rosetta.bit; touch $(BUILD_DIR_PYNQ)/rosetta.tcl
+	mkdir -p $(BUILD_DIR_PYNQ); cp $(GEN_BITFILE_PATH) $(BUILD_DIR_PYNQ)/rosetta.bit; cp $(BITFILE_PRJDIR)/rosetta.tcl $(BUILD_DIR_PYNQ)/
 
 # copy all user sources and driver sources to the deployment folder
 pynq_sw: hw_driver

--- a/src/main/cpp/app/main.cpp
+++ b/src/main/cpp/app/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <ctime>
 using namespace std;
 #include "platform.h"
 
@@ -6,6 +7,8 @@ using namespace std;
 #include "DRAMExample.hpp"
 void Run_DRAMExample(WrapperRegDriver * platform) {
   DRAMExample t(platform);
+  struct timespec tic, toc;
+  float total_time;
 
   cout << "Signature: " << hex << t.get_signature() << dec << endl;
   unsigned int ub = 0;
@@ -31,9 +34,13 @@ void Run_DRAMExample(WrapperRegDriver * platform) {
   t.set_baseAddr((AccelDblReg) accelBuf);
   t.set_byteCount(bufsize);
 
+  clock_gettime(CLOCK_MONOTONIC, &tic);
+
   t.set_start(1);
 
   while(t.get_finished() != 1);
+
+  clock_gettime(CLOCK_MONOTONIC, &toc);
 
   platform->deallocAccelBuffer(accelBuf);
   delete [] hostBuf;
@@ -42,6 +49,12 @@ void Run_DRAMExample(WrapperRegDriver * platform) {
   cout << "Result = " << res << " expected " << golden << endl;
   unsigned int cc = t.get_cycleCount();
   cout << "#cycles = " << cc << " cycles per word = " << (float)cc/(float)ub << endl;
+
+  total_time = ((float)(toc.tv_nsec-tic.tv_nsec))/((float)1000000000) + (float)(toc.tv_sec-tic.tv_sec);
+  cout << "Elapsed time(s): " << total_time << ", ";
+  cout << "Time per word(s): " << total_time/ub << ", ";
+  cout << "Frequency(Mhz): " << ub/(1000000*total_time) << endl;
+
   t.set_start(0);
 }
 

--- a/src/main/script/host/make-vivado-project.tcl
+++ b/src/main/script/host/make-vivado-project.tcl
@@ -89,6 +89,8 @@ connect_bd_net [get_bd_pins /PYNQWrapper_0/io_led5_r] [get_bd_ports led5_r]
 regenerate_bd_layout
 validate_bd_design
 save_bd_design
+# write block design tcl
+write_bd_tcl $config_proj_dir/rosetta.tcl
 
 # use global mode (no out-of-context) for bd synthesis
 #set_property synth_checkpoint_mode None [get_files $config_proj_dir/$config_proj_name.srcs/sources_1/bd/procsys/procsys.bd]


### PR DESCRIPTION
On the Pynq v2.1 image, the clock wasn't being set when the overlay was loaded. Instead of creating a blank tcl file, we write the block design to a tcl file. This allows the clock to be set when the overlay is loaded.

I haven't tested it on the Pynq v1.4 image, but according to @PeterOgden. The clock is probably not set under this image either. To more easily test this, I've added a wall clock timer to the DRAM example. You can also test this by running the following from ipython:

```python
import pynq.ps
from pynq import Overlay
print(pynq.ps.Clocks.fclk0_mhz)
o = Overlay("rosetta.bit")
o.download()
print(pynq.ps.Clocks.fclk0_mhz)
```

Note that a clock frequency of 150MHz is not supported, so a frequency of 142.857143MHz is set instead. You can confirm this by running:

```python
import pynq.ps
pynq.ps.Clocks.set_fclk(0, clk_mhz=150.0)
print(pynq.ps.Clocks.fclk0_mhz)
```